### PR TITLE
`fn windows`: do not panic for a size of 0

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -11,7 +11,6 @@
 use crate::cmp::Ordering::{self, Greater, Less};
 use crate::marker::Copy;
 use crate::mem;
-use crate::num::NonZeroUsize;
 use crate::ops::{FnMut, Range, RangeBounds};
 use crate::option::Option;
 use crate::option::Option::{None, Some};
@@ -725,12 +724,8 @@ impl<T> [T] {
     }
 
     /// Returns an iterator over all contiguous windows of length
-    /// `size`. The windows overlap. If the slice is shorter than
+    /// `size`. The windows may overlap. If the slice is shorter than
     /// `size`, the iterator returns no values.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `size` is 0.
     ///
     /// # Examples
     ///
@@ -753,7 +748,6 @@ impl<T> [T] {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn windows(&self, size: usize) -> Windows<'_, T> {
-        let size = NonZeroUsize::new(size).expect("size is zero");
         Windows::new(self, size)
     }
 
@@ -1199,11 +1193,6 @@ impl<T> [T] {
     ///
     /// If `N` is greater than the size of the slice, it will return no windows.
     ///
-    /// # Panics
-    ///
-    /// Panics if `N` is 0. This check will most probably get changed to a compile time
-    /// error before this method gets stabilized.
-    ///
     /// # Examples
     ///
     /// ```
@@ -1220,7 +1209,6 @@ impl<T> [T] {
     #[unstable(feature = "array_windows", issue = "75027")]
     #[inline]
     pub fn array_windows<const N: usize>(&self) -> ArrayWindows<'_, T, N> {
-        assert_ne!(N, 0);
         ArrayWindows::new(self)
     }
 

--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -727,6 +727,18 @@ fn test_array_windows_infer() {
 }
 
 #[test]
+fn test_array_windows_zero() {
+    let v: &[i32] = &[0, 1, 2];
+    let mut iter = v.array_windows::<0>();
+
+    assert_eq!(iter.next(), Some(&[]));
+    assert_eq!(iter.next(), Some(&[]));
+    assert_eq!(iter.next(), Some(&[]));
+    assert_eq!(iter.next(), Some(&[]));
+    assert_eq!(iter.next(), None);
+}
+
+#[test]
 fn test_array_windows_count() {
     let v: &[i32] = &[0, 1, 2, 3, 4, 5];
     let c = v.array_windows::<3>();
@@ -739,6 +751,10 @@ fn test_array_windows_count() {
     let v3: &[i32] = &[];
     let c3 = v3.array_windows::<2>();
     assert_eq!(c3.count(), 0);
+
+    let v4: &[i32] = &[0, 1, 2];
+    let c4 = c4.array_windows::<0>();
+    assert_eq!(c4.count(), 4);
 }
 
 #[test]
@@ -1050,6 +1066,10 @@ fn test_windows_count() {
     let v3: &[i32] = &[];
     let c3 = v3.windows(2);
     assert_eq!(c3.count(), 0);
+
+    let v4: &[i32] = &[0, 1, 2, 3, 4];
+    let c4 = v4.windows(0);
+    assert_eq!(c4.count(), 6);
 }
 
 #[test]


### PR DESCRIPTION
I understand `fn windows` as
```rust
let mut start = 0;
while start + size <= slice.len() {
    yield &slice[start..start+size];
    start += 1;
}
```
so this method seems well defined for a size of 0 to me.